### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/shortcutui",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A JupyterLab extension for managing keyboard shortcuts",
   "author": "Jenna Landy, Noah Stapp, and Alena Mueller",
   "keywords": [


### PR DESCRIPTION
I was trying to publish a completely different package to npmjs.org and didn't realize I was in my shortcutui clone instead of the proper package directory. Long story short, I accidentally released a bad 0.3.3 without a proper build. I unpublished that version right away so no one should get the bad build. The next time someone publishes shortcutui though, a new version number will be needed since 0.3.3 can't be released again.

Sorry for the hiccup! TIL I have npm publish writes to @jupyterlab 🤦‍♂️