### PR TITLE
Support JupyterLab 2 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/shortcutui",
-  "version": "0.4.0",
+  "version": "0.5.0-beta.1",
   "description": "A JupyterLab extension for managing keyboard shortcuts",
   "author": "Jenna Landy, Noah Stapp, and Alena Mueller",
   "keywords": [
@@ -30,29 +30,30 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.1.0",
-    "@jupyterlab/apputils": "^1.0.1",
-    "@jupyterlab/coreutils": "^3.1.0",
-    "@jupyterlab/mainmenu": "^1.1.0",
-    "@phosphor/domutils": "^1.1.3",
-    "@phosphor/keyboard": "^1.1.3",
-    "@phosphor/widgets": "^1.9.0",
-    "react": "~16.8.4",
+    "@jupyterlab/application": "^2.0.0-alpha.4",
+    "@jupyterlab/apputils": "^2.0.0-alpha.4",
+    "@jupyterlab/coreutils": "^4.0.0-alpha.4",
+    "@jupyterlab/mainmenu": "^2.0.0-alpha.4",
+    "@jupyterlab/settingregistry": "^2.0.0-beta.1",
+    "@lumino/domutils": "^1.1.6",
+    "@lumino/keyboard": "^1.1.5",
+    "@lumino/widgets": "^1.9.4",
+    "react": "~16.9.0",
     "typestyle": "^2.0.4"
   },
   "devDependencies": {
-    "@types/react": "~16.8.18",
-    "@types/react-dom": "~16.8.4",
-    "prettier": "^1.18.2",
+    "@types/react": "~16.9.11",
+    "@types/react-dom": "~16.9.4",
+    "prettier": "^1.19.1",
     "rimraf": "^3.0.0",
-    "tslint": "^5.18.0",
+    "tslint": "^5.20.1",
     "tslint-plugin-prettier": "^2.0.1",
-    "typescript": "~3.6.2"
+    "typescript": "~3.7.3"
   },
   "jupyterlab": {
     "extension": true
   },
   "resolutions": {
-    "@types/react": "~16.8.4"
+    "@types/react": "^16.9.11"
   }
 }

--- a/src/ShortcutWidget.tsx
+++ b/src/ShortcutWidget.tsx
@@ -1,17 +1,18 @@
 import { VDomRenderer, VDomModel } from '@jupyterlab/apputils';
 
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+import { CommandRegistry } from '@lumino/commands';
+
+import { IDisposable } from '@lumino/disposable';
+
+import { Widget, Title, Menu } from '@lumino/widgets';
+
 import * as React from 'react';
 
-import { ShortcutUI } from './components/ShortcutUI';
-
-import { ISettingRegistry } from '@jupyterlab/coreutils';
-
-import { CommandRegistry } from '@phosphor/commands';
-
-import { Widget, Title, Menu } from '@phosphor/widgets';
-
 import * as ReactDOM from 'react-dom';
-import { IDisposable } from '@phosphor/disposable';
+
+import { ShortcutUI } from './components/ShortcutUI';
 
 /** All external actions, setting commands, getting command list ... */
 export interface IShortcutUIexternal {
@@ -37,7 +38,7 @@ export default class ShortcutWidget extends VDomRenderer<VDomModel> {
   reactComponent: React.ReactElement<any>;
 
   constructor(external: IShortcutUIexternal) {
-    super();
+    super(undefined);
     this.height = -1;
     this.width = -1;
     this.external = external;

--- a/src/components/ShortcutInput.tsx
+++ b/src/components/ShortcutInput.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { classes } from 'typestyle';
 
-import { EN_US } from '@phosphor/keyboard';
+import { EN_US } from '@lumino/keyboard';
 
 import {
   InputStyle,

--- a/src/components/ShortcutItem.tsx
+++ b/src/components/ShortcutItem.tsx
@@ -2,7 +2,7 @@ import { ShortcutObject, ErrorObject, TakenByObject } from '../index';
 
 import { ShortcutInput } from './ShortcutInput';
 
-import { Platform } from '@phosphor/domutils';
+import { Platform } from '@lumino/domutils';
 
 import { classes } from 'typestyle';
 

--- a/src/components/ShortcutUI.tsx
+++ b/src/components/ShortcutUI.tsx
@@ -1,22 +1,23 @@
-import { ISettingRegistry } from '@jupyterlab/coreutils';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
-import { ArrayExt, StringExt } from '@phosphor/algorithm';
+import { ArrayExt, StringExt } from '@lumino/algorithm';
 
-import { ShortcutList } from './ShortcutList';
-
-import { TopNav } from './TopNav';
-
-import { ShortcutObject, ErrorObject, TakenByObject } from '../index';
-
-import { IShortcutUIexternal } from '../ShortcutWidget';
+import { ReadonlyJSONArray } from '@lumino/coreutils';
 
 import {
   TopWhitespaceStyle,
   ShortcutUIStyle
 } from '../componentStyle/ShortcutUIStyle';
 
+import { ShortcutObject, ErrorObject, TakenByObject } from '../index';
+
+import { IShortcutUIexternal } from '../ShortcutWidget';
+
+import { ShortcutList } from './ShortcutList';
+
+import { TopNav } from './TopNav';
+
 import * as React from 'react';
-import { ReadonlyJSONArray } from '@phosphor/coreutils';
 
 const enum MatchType {
   Label,

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,8 +1,10 @@
+import { Menu } from '@lumino/widgets';
+
 import * as React from 'react';
 
 import { classes } from 'typestyle';
 
-import { Menu } from '@phosphor/widgets';
+import { CellStyle } from '../componentStyle/ShortcutItemStyle';
 
 import {
   TopStyle,
@@ -23,10 +25,10 @@ import {
   controlIconStyle
 } from '../componentStyle/TopNavStyle';
 
-import { CellStyle } from '../componentStyle/ShortcutItemStyle';
+import { IShortcutUIexternal } from '../ShortcutWidget';
 
 import { ShortcutTitleItem } from './ShortcutTitleItem';
-import { IShortcutUIexternal } from '../ShortcutWidget';
+
 import { UISize } from './ShortcutUI';
 
 export interface IAdvancedOptionsProps {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,8 +4,6 @@ import {
   JupyterFrontEnd
 } from '@jupyterlab/application';
 
-import { ISettingRegistry } from '@jupyterlab/coreutils';
-
 import {
   ICommandPalette,
   MainAreaWidget,
@@ -14,12 +12,15 @@ import {
 
 import { IMainMenu } from '@jupyterlab/mainmenu';
 
-import { Widget, Menu } from '@phosphor/widgets';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
+
+import { CommandRegistry } from '@lumino/commands';
+
+import { Widget, Menu } from '@lumino/widgets';
 
 import ShortcutWidget, { IShortcutUIexternal } from './ShortcutWidget';
 
 import '../style/variables.css';
-import { CommandRegistry } from '@phosphor/commands';
 
 /** Object for shortcut items */
 export class ShortcutObject {


### PR DESCRIPTION
*Update imports and dependencies for JupyterLab 2 **beta***

- [x] Bump to version `0.5.0-beta.1`
- [x] Change `@phosphor/*` to `@lumino/*`
- [x] Use setting registry from new `@jupyterlab/settingregistry` package
- [x] Update other dependency version numbers to match JupyterLab

#### Notes
- These changes are sufficient to update the shortcut UI extension to work with JupyterLab 2 *after* https://github.com/jupyterlab/jupyterlab/pull/7699 is released. Until then, the `jupyter labextension build` step will fail.
- This PR uses beta versions of the JupyterLab packages! This is for testing against the new version of JupyterLab.