### PR TITLE
Update Binder to use JLab 2.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: jupyterlab-shortcutui
+channels:
+- conda-forge
+- conda-forge/label/prerelease-jupyterlab
+dependencies:
+- jupyterlab=2
+- nodejs
+

--- a/postBuild
+++ b/postBuild
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-jupyter labextension install @jupyterlab/shortcutui
+jlpm && jlpm run build && jupyter labextension install . --debug
+


### PR DESCRIPTION
With this configuration, Binder will always point to the master branch and build the install the extension from the repo.

Once 2.0 final it out, `postBuild` could instead install a released version (if this extension is not merged into core).

To test this branch: https://mybinder.org/v2/gh/jtpio/jupyterlab-shortcutui/binder?urlpath=lab