### PR TITLE
Fix build.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
+    "esModuleInterop": true,
     "noImplicitAny": false,
     "noEmitOnError": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
`esModuleInterop` needs to be true for building against JupyterLab 2.0. Fixes:
```
  node_modules/@types/react/index.d.ts:61:1
    61 export = React;
       ~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```